### PR TITLE
nd_bootstrap.py: fix default retries

### DIFF
--- a/nd_bootstrap.py
+++ b/nd_bootstrap.py
@@ -75,7 +75,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--retries",
         type=int,
-        default=10,
+        default=100,
         help="Number of retries for polling the status (bootstrap and services). Ignored if --poll-status is not set or --dry-run is set",
     )
     parser.add_argument(


### PR DESCRIPTION
While the default retries was changed from 10 to 100 in bootstrap.py, it was not updated in the argparse configuration in nd_bootstrap.py.